### PR TITLE
Update template for bootstrap 5 to fix "Add slots" dropdown menu not working in Moodle 5

### DIFF
--- a/templates/action_menu_trigger.mustache
+++ b/templates/action_menu_trigger.mustache
@@ -89,7 +89,7 @@
         class="{{triggerextraclasses}} dropdown-toggle icon-no-margin"
         id="action-menu-toggle-{{instance}}"
         aria-label="{{title}}"
-        data-toggle="dropdown"
+        data-bs-toggle="dropdown"
         role="{{triggerrole}}"
         aria-haspopup="true"
         aria-expanded="false"


### PR DESCRIPTION
Moodle 5.0 has migrated to booststrap 5. As a consequence, the dropdown menu "Add slots" in the scheduler activity is no longer working. This is because data attributes have been namespaced. `data-toggle="dropdown"`  is now `data-bs-toggle="dropdown"`. 
This pull request adapts the template with the new attribute name.