### PR TITLE
MDL-83231 - remove FEATURE_GROUPMEMBERSONLY constant

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -375,8 +375,6 @@ function scheduler_supports($feature) {
             return true;
         case FEATURE_GROUPINGS:
             return true;
-        case FEATURE_GROUPMEMBERSONLY:
-            return true;
         case FEATURE_MOD_INTRO:
             return true;
         case FEATURE_COMPLETION_TRACKS_VIEWS:


### PR DESCRIPTION
The FEATURE_GROUPMEMBERSONLY constant has been deprecated and is no longer supported. It should be removed from any plugin code.

For more information see MDL-83231

required in 5.3